### PR TITLE
Downgrade bitvec to 0.20.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Joe Doyle <joe@translucence.net>, Jeb Bearer <jeb.bearer@translucenc
 [dependencies]
 arbitrary = { version="1.0", features=["derive"] }
 ark-serialize = { version = "0.3.0", features = ["derive"] }
-bitvec = "^0.22"
+bitvec = "=0.20.4"
 generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Required to add reef as a dependency in CAPE because ether-rs is incompatible with higher versions of bitvec.

Matches the version in spectrum zerok_lib:
https://github.com/SpectrumXYZ/spectrum/blob/4f961d7a9cb8ff6168dcafab48ec155d59049316/zerok/zerok_lib/Cargo.toml#L38

