### PR TITLE
Make Commitment an associated type.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 arbitrary = { version="1.0", features=["derive"] }
 ark-serialize = { version = "0.3.0", features = ["derive"] }
 bitvec = "=0.20.1"
+derivative = "2.2"
 funty = "=1.1.0"
 generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"


### PR DESCRIPTION
Usually, it will be instantiated using HashCommitment<Self>, which this crate provides. However, this gives flexibility to delegate through an intermediate type, if desired. For example, in Espresso, Both ValidatorState and LedgerCommitmentOpening can have `type Commitment = LedgerStateCommitment`.

We provide a type alias `type Commitment<T> = <T as Committable>::Commitment` for convenience and compatibility.