### PR TITLE
fix: Commitment now has PhantomData<fn(&T)>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub trait Committable {
     feature = "serde",
     serde(bound = "", try_from = "TaggedBase64", into = "TaggedBase64")
 )]
-pub struct Commitment<T: ?Sized + Committable>(Array, PhantomData<T>);
+pub struct Commitment<T: ?Sized + Committable>(Array, PhantomData<fn(&T)>);
 
 impl<T: ?Sized + Committable> Commitment<T> {
     pub fn into_bits(self) -> BitVec<u8, bitvec::order::Lsb0> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,11 @@ pub trait Committable {
     }
 }
 
-#[derive(Derivative, AsRef, Into)]
+#[derive(Derivative, AsRef, Into, Copy)]
 #[derivative(
     Clone(bound = ""),
     Debug(bound = ""),
-    Copy(bound = ""),
+    // Copy(bound = ""),
     PartialEq(bound = ""),
     Eq(bound = ""),
     PartialOrd(bound = ""),
@@ -128,7 +128,7 @@ impl<T: ?Sized + Committable> From<Commitment<T>> for [u8; 32] {
 
 impl<'a, T: ?Sized + Committable> Arbitrary<'a> for Commitment<T> {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self(u.arbitrary()?, PhantomData::default()))
+        Ok(Self(u.arbitrary()?, PhantomData))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@ pub trait Committable {
 #[derivative(
     Clone(bound = ""),
     Debug(bound = ""),
-    // Copy(bound = ""),
     PartialEq(bound = ""),
     Eq(bound = ""),
     PartialOrd(bound = ""),


### PR DESCRIPTION
fix #32 

@jbearer I'll have to take your word for it. Couldn't find much docs on this except the [Rustonomicon](https://doc.rust-lang.org/nomicon/phantom-data.html#table-of-phantomdata-patterns) and I don't understand it.