### PR TITLE
feat: New trait CommitmentBounds for Commitment trait bounds, safer default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,9 @@ impl<T> CommitmentBounds for T where
 {
 }
 
+#[cfg(not(feature = "serde"))]
+trait CommitmentBounds: CommitmentBoundsSerdeless {}
+
 impl<T: ?Sized + Committable> Commitment<T> {
     pub fn into_bits(self) -> BitVec<u8, bitvec::order::Lsb0> {
         BitVec::try_from(self.0.to_vec()).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,26 +107,6 @@ pub trait CommitmentBoundsSerdeless:
     fn default_commitment_no_preimage() -> Self;
 }
 
-impl<T> CommitmentBoundsSerdeless for T
-where
-    T: AsRef<[u8]>
-        + Clone
-        + Copy
-        + Debug
-        + Default // additional bound beyond CommitmentBoundsSerdeless
-        + Eq
-        + Hash
-        + PartialEq
-        + Send
-        + Sync
-        + 'static,
-{
-    fn default_commitment_no_preimage() -> Self {
-        Self::default()
-    }
-}
-
-// `Commitment<T>` needs its own impl because it's not `Default`
 impl<T> CommitmentBoundsSerdeless for Commitment<T>
 where
     T: Committable + 'static,
@@ -139,12 +119,6 @@ where
 #[cfg(feature = "serde")]
 pub trait CommitmentBounds:
     CommitmentBoundsSerdeless + for<'a> Deserialize<'a> + Serialize
-{
-}
-
-#[cfg(feature = "serde")]
-impl<T> CommitmentBounds for T where
-    T: CommitmentBoundsSerdeless + for<'a> Deserialize<'a> + Serialize
 {
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub struct Commitment<T: ?Sized + Committable>(Array, PhantomData<fn(&T)>);
 
 /// Consolidate trait bounds for cryptographic commitments.
 pub trait CommitmentBoundsSerdeless:
-    AsRef<[u8]> + Clone + Copy + Debug + Eq + PartialEq + Hash
+    AsRef<[u8]> + Clone + Copy + Debug + Eq + Hash + PartialEq + Send + Sync + 'static
 {
     /// Create a default commitment with no preimage.
     ///
@@ -115,8 +115,11 @@ where
         + Debug
         + Default // additional bound beyond CommitmentBoundsSerdeless
         + Eq
+        + Hash
         + PartialEq
-        + Hash,
+        + Send
+        + Sync
+        + 'static,
 {
     fn default_commitment_no_preimage() -> Self {
         Self::default()
@@ -126,7 +129,7 @@ where
 // `Commitment<T>` needs its own impl because it's not `Default`
 impl<T> CommitmentBoundsSerdeless for Commitment<T>
 where
-    T: Committable,
+    T: Committable + 'static,
 {
     fn default_commitment_no_preimage() -> Self {
         Commitment([0u8; 32], PhantomData)


### PR DESCRIPTION
fix #36 

- The new trait `CommitmentBounds` has a method `default_commitment_no_preimage`. This is how users create a default commitment without `Default` as required by #36.
- The blanket impl requires `Default` in addition to other trait bounds for `Commitment<T>`. We use it to implement `default_commitment_no_preimage`
- We also provide an impl for `Commitment<T>` (which is not covered by the blanket impl)
- I added a test to ensure that `Commitment<T>` has all the expected traits, so as to avoid stupidity such as #34 in the future.

# Why not do this downstream?

As discussed with @jbearer , the original plan was to do all this downstream. However, any attempt to do so hits an insidious build error:

> conflicting implementations of trait `CommitmentBounds` for type `commit::Commitment<_>`
> upstream crates may add a new impl of trait `std::default::Default` for type `commit::Commitment<_>` in future versions

We avoid this error by doing it here instead.