### PR TITLE
fix: add missing CommitmentBounds impl for Commitment<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,8 @@ pub trait CommitmentBounds:
 #[cfg(not(feature = "serde"))]
 trait CommitmentBounds: CommitmentBoundsSerdeless {}
 
+impl<T> CommitmentBounds for Commitment<T> where T: Committable + 'static {}
+
 impl<T: ?Sized + Committable> Commitment<T> {
     pub fn into_bits(self) -> BitVec<u8, bitvec::order::Lsb0> {
         BitVec::try_from(self.0.to_vec()).unwrap()


### PR DESCRIPTION
PR #37 provided a `CommitmentBoundsSerdeless` impl for `Commitment<T>` but forgot an impl for `CommitmentBounds`. 🤦 