### PR TITLE
Implement From<[u8; 32]> for Commitment<T>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "committable"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.65.0"
 authors = ["Espresso Systems <hello@espressosys.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 // `Clippy` is not happy with the `derivative` crate in rust 1.73.
 // Remove this statement when `Clippy` or `derivative` fixes it.
 // See: https://github.com/mcarton/rust-derivative/issues/115
-#![allow(clippy::incorrect_partial_ord_impl_on_ord_type, unused_imports)]
+#![allow(clippy::non_canonical_partial_ord_impl, unused_imports)]
 
 use arbitrary::{Arbitrary, Unstructured};
 use bitvec::vec::BitVec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,10 +153,8 @@ impl<T: ?Sized + Committable> From<Commitment<T>> for [u8; 32] {
     }
 }
 
-impl<T: ?Sized + Committable> From<[u8; 32]> for Commitment<T> {
-    fn from(array: [u8; 32]) -> Self {
-        Self(array, PhantomData)
-    }
+pub fn from_raw<T: ?Sized + Committable>(bytes: [u8; 32]) -> Commitment<T> {
+    Commitment(bytes, PhantomData)
 }
 
 impl<'a, T: ?Sized + Committable> Arbitrary<'a> for Commitment<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub trait CommitmentBounds:
 }
 
 #[cfg(not(feature = "serde"))]
-trait CommitmentBounds: CommitmentBoundsSerdeless {}
+pub trait CommitmentBounds: CommitmentBoundsSerdeless {}
 
 impl<T> CommitmentBounds for Commitment<T> where T: Committable + 'static {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,10 @@ impl<T: ?Sized + Committable> Commitment<T> {
     pub fn into_bits(self) -> BitVec<u8, bitvec::order::Lsb0> {
         BitVec::try_from(self.0.to_vec()).unwrap()
     }
+
+    pub fn from_raw(bytes: [u8; 32]) -> Self {
+        Self(bytes, PhantomData)
+    }
 }
 
 // clippy pacification: `non_canonical_clone_impl` aka `incorrect_clone_impl_on_copy_type`
@@ -151,10 +155,6 @@ impl<T: ?Sized + Committable> From<Commitment<T>> for [u8; 32] {
     fn from(v: Commitment<T>) -> Self {
         v.0
     }
-}
-
-pub fn from_raw<T: ?Sized + Committable>(bytes: [u8; 32]) -> Commitment<T> {
-    Commitment(bytes, PhantomData)
 }
 
 impl<'a, T: ?Sized + Committable> Arbitrary<'a> for Commitment<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,12 @@ impl<T: ?Sized + Committable> From<Commitment<T>> for [u8; 32] {
     }
 }
 
+impl<T: ?Sized + Committable> From<[u8; 32]> for Commitment<T> {
+    fn from(array: [u8; 32]) -> Self {
+        Self(array, PhantomData)
+    }
+}
+
 impl<'a, T: ?Sized + Committable> Arbitrary<'a> for Commitment<T> {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(u.arbitrary()?, PhantomData))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 // `Clippy` is not happy with the `derivative` crate in rust 1.73.
 // Remove this statement when `Clippy` or `derivative` fixes it.
 // See: https://github.com/mcarton/rust-derivative/issues/115
-#![allow(clippy::non_canonical_partial_ord_impl, unused_imports)]
+#![allow(clippy::incorrect_partial_ord_impl_on_ord_type, unused_imports)]
 
 use arbitrary::{Arbitrary, Unstructured};
 use bitvec::vec::BitVec;


### PR DESCRIPTION
### This PR:
Implements `from_raw`, which allows us to create a `Commitment<T>` from a raw sequence of bytes. In particular, this allows us to cast between commitments of different types.

### This PR does not:

### Key places to review:
